### PR TITLE
Fix content JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,5 @@ There are several checks performed:
 
 ### Logging
 
-* The application uses [logrus](https://github.com/Sirupsen/logrus); the log file is initialised in [main.go](main.go).
+* The application uses [logrus](https://github.com/sirupsen/logrus); the log file is initialised in [main.go](main.go).
 * NOTE: `/__build-info` and `/__gtg` endpoints are not logged as they are called every second from varnish/vulcand and this information is not needed in logs/splunk.

--- a/content/enriched_content.go
+++ b/content/enriched_content.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -13,7 +12,7 @@ type Client interface {
 const enrichedContentPath = "/enrichedcontent/"
 
 type Fetcher interface {
-	GetContent(uuid, tid string) (map[string]interface{}, error)
+	GetContent(uuid, tid string) ([]byte, error)
 }
 
 type EnrichedContentFetcher struct {
@@ -24,7 +23,7 @@ type EnrichedContentFetcher struct {
 	Authorization            string
 }
 
-func (e *EnrichedContentFetcher) GetContent(uuid, tid string) (map[string]interface{}, error) {
+func (e *EnrichedContentFetcher) GetContent(uuid, tid string) ([]byte, error) {
 	req, err := http.NewRequest("GET", e.EnrichedContentBaseURL+enrichedContentPath+uuid, nil)
 	if err != nil {
 		return nil, err
@@ -53,11 +52,10 @@ func (e *EnrichedContentFetcher) GetContent(uuid, tid string) (map[string]interf
 		return nil, fmt.Errorf("EnrichedContent returned HTTP %v", resp.StatusCode)
 	}
 
-	var result map[string]interface{}
-	dec := json.NewDecoder(resp.Body)
-	err = dec.Decode(&result)
-	return result, err
+	var body []byte
+	_, err = resp.Body.Read(body)
 
+	return body, err
 }
 
 func (e *EnrichedContentFetcher) CheckHealth() (string, error) {

--- a/content/enriched_content.go
+++ b/content/enriched_content.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -52,10 +53,7 @@ func (e *EnrichedContentFetcher) GetContent(uuid, tid string) ([]byte, error) {
 		return nil, fmt.Errorf("EnrichedContent returned HTTP %v", resp.StatusCode)
 	}
 
-	var body []byte
-	_, err = resp.Body.Read(body)
-
-	return body, err
+	return ioutil.ReadAll(resp.Body)
 }
 
 func (e *EnrichedContentFetcher) CheckHealth() (string, error) {

--- a/content/export_test.go
+++ b/content/export_test.go
@@ -1,17 +1,17 @@
 package content
 
 import (
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestExporterHandleContentWithValidContent(t *testing.T) {
 	tid := "tid_1234"
 	stubUuid := "uuid1"
 	date := "2017-10-09"
-	testData := make(map[string]interface{})
-	testData["uuid"] = stubUuid
+	testData := []byte(stubUuid)
 	fetcher := &mockFetcher{expectedUuid: stubUuid, expectedTid: tid, result: testData}
 	updater := &mockUpdater{expectedUuid: stubUuid, expectedTid: tid, expectedDate: date, expectedPayload: testData}
 
@@ -27,8 +27,7 @@ func TestExporterHandleContentWithErrorFromFetcher(t *testing.T) {
 	tid := "tid_1234"
 	stubUuid := "uuid1"
 	date := "2017-10-09"
-	testData := make(map[string]interface{})
-	testData["uuid"] = stubUuid
+	testData := []byte("uuid: " + stubUuid)
 	fetcher := &mockFetcher{expectedUuid: stubUuid, expectedTid: tid, result: testData, err: errors.New("Fetcher err")}
 	updater := &mockUpdater{}
 
@@ -45,8 +44,7 @@ func TestExporterHandleContentWithErrorFromUpdater(t *testing.T) {
 	tid := "tid_1234"
 	stubUuid := "uuid1"
 	date := "2017-10-09"
-	testData := make(map[string]interface{})
-	testData["uuid"] = stubUuid
+	testData := []byte("uuid: " + stubUuid)
 	fetcher := &mockFetcher{expectedUuid: stubUuid, expectedTid: tid, result: testData}
 	updater := &mockUpdater{expectedUuid: stubUuid, expectedTid: tid, expectedDate: date, expectedPayload: testData, err: errors.New("Updater err")}
 
@@ -62,12 +60,12 @@ func TestExporterHandleContentWithErrorFromUpdater(t *testing.T) {
 type mockFetcher struct {
 	t                         *testing.T
 	expectedUuid, expectedTid string
-	result                    map[string]interface{}
+	result                    []byte
 	err                       error
 	called                    bool
 }
 
-func (f *mockFetcher) GetContent(uuid, tid string) (map[string]interface{}, error) {
+func (f *mockFetcher) GetContent(uuid, tid string) ([]byte, error) {
 	assert.Equal(f.t, f.expectedUuid, uuid)
 	assert.Equal(f.t, f.expectedTid, tid)
 	f.called = true
@@ -77,12 +75,12 @@ func (f *mockFetcher) GetContent(uuid, tid string) (map[string]interface{}, erro
 type mockUpdater struct {
 	t                                       *testing.T
 	expectedUuid, expectedTid, expectedDate string
-	expectedPayload                         map[string]interface{}
+	expectedPayload                         []byte
 	err                                     error
 	called                                  bool
 }
 
-func (u *mockUpdater) Upload(content map[string]interface{}, tid, uuid, date string) error {
+func (u *mockUpdater) Upload(content []byte, tid, uuid, date string) error {
 	assert.Equal(u.t, u.expectedUuid, uuid)
 	assert.Equal(u.t, u.expectedTid, tid)
 	assert.Equal(u.t, u.expectedDate, date)

--- a/content/s3_writer.go
+++ b/content/s3_writer.go
@@ -2,7 +2,6 @@ package content
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -10,7 +9,7 @@ import (
 const s3WriterPath = "/content/"
 
 type Updater interface {
-	Upload(content map[string]interface{}, tid, uuid, date string) error
+	Upload(content []byte, tid, uuid, date string) error
 	Delete(uuid, tid string) error
 }
 
@@ -40,9 +39,9 @@ func (u *S3Updater) Delete(uuid, tid string) error {
 	return nil
 }
 
-func (u *S3Updater) Upload(content map[string]interface{}, tid, uuid, date string) error {
+func (u *S3Updater) Upload(content []byte, tid, uuid, date string) error {
 	buf := new(bytes.Buffer)
-	err := json.NewEncoder(buf).Encode(content)
+	_, err := buf.Read(content)
 	if err != nil {
 		return err
 	}

--- a/content/s3_writer.go
+++ b/content/s3_writer.go
@@ -41,7 +41,7 @@ func (u *S3Updater) Delete(uuid, tid string) error {
 
 func (u *S3Updater) Upload(content []byte, tid, uuid, date string) error {
 	buf := new(bytes.Buffer)
-	_, err := buf.Read(content)
+	_, err := buf.Write(content)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Issue**: JSON fields inside an archive file are sorted in alphabetical order, instead of keeping the same format that comes from Enriched Content.

**Fix**: Content body will be kept and processed as `[]byte`, without decoding/encoding it to a JSON form.  