### PR TITLE
Improvement: Errors when content is not accessible

### DIFF
--- a/content/export.go
+++ b/content/export.go
@@ -8,7 +8,7 @@ import (
 const DefaultDate = "0000-00-00"
 
 type Stub struct {
-	Uuid, Date string
+	Uuid, Date       string
 	CanBeDistributed *string
 }
 

--- a/content/export.go
+++ b/content/export.go
@@ -9,6 +9,7 @@ const DefaultDate = "0000-00-00"
 
 type Stub struct {
 	Uuid, Date string
+	CanBeDistributed *string
 }
 
 type Exporter struct {

--- a/content/export_test.go
+++ b/content/export_test.go
@@ -16,7 +16,7 @@ func TestExporterHandleContentWithValidContent(t *testing.T) {
 	updater := &mockUpdater{expectedUuid: stubUuid, expectedTid: tid, expectedDate: date, expectedPayload: testData}
 
 	exporter := NewExporter(fetcher, updater)
-	err := exporter.HandleContent(tid, Stub{stubUuid, date})
+	err := exporter.HandleContent(tid, Stub{stubUuid, date, nil})
 
 	assert.NoError(t, err)
 	assert.True(t, fetcher.called)
@@ -32,7 +32,7 @@ func TestExporterHandleContentWithErrorFromFetcher(t *testing.T) {
 	updater := &mockUpdater{}
 
 	exporter := NewExporter(fetcher, updater)
-	err := exporter.HandleContent(tid, Stub{stubUuid, date})
+	err := exporter.HandleContent(tid, Stub{stubUuid, date, nil})
 
 	assert.Error(t, err)
 	assert.Equal(t, "Error getting content for uuid1: Fetcher err", err.Error())
@@ -49,7 +49,7 @@ func TestExporterHandleContentWithErrorFromUpdater(t *testing.T) {
 	updater := &mockUpdater{expectedUuid: stubUuid, expectedTid: tid, expectedDate: date, expectedPayload: testData, err: errors.New("Updater err")}
 
 	exporter := NewExporter(fetcher, updater)
-	err := exporter.HandleContent(tid, Stub{stubUuid, date})
+	err := exporter.HandleContent(tid, Stub{stubUuid, date, nil})
 
 	assert.Error(t, err)
 	assert.Equal(t, "Error uploading content for uuid1: Updater err", err.Error())

--- a/content/inquirer.go
+++ b/content/inquirer.go
@@ -61,5 +61,5 @@ func mapStub(result map[string]interface{}) (Stub, error) {
 		return Stub{}, fmt.Errorf("No uuid field found in iter result: %v", result)
 	}
 
-	return Stub{docUUID.(string), GetDateOrDefault(result)}, nil
+	return Stub{Uuid: docUUID.(string), Date: GetDateOrDefault(result), CanBeDistributed: nil}, nil
 }

--- a/queue/kafka.go
+++ b/queue/kafka.go
@@ -1,12 +1,12 @@
 package queue
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/Financial-Times/content-exporter/export"
 	"github.com/Financial-Times/kafka-client-go/kafka"
+	"errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -105,7 +105,7 @@ func (h *KafkaListener) HandleMessage(msg kafka.FTMessage) error {
 		h.Cleanup.Do(func() {
 			close(h.received)
 		})
-		return fmt.Errorf("Service is shutdown")
+		return errors.New("Service is shutdown")
 	}
 
 	tid := msg.Headers["X-Request-Id"]
@@ -117,7 +117,7 @@ func (h *KafkaListener) HandleMessage(msg kafka.FTMessage) error {
 				h.Cleanup.Do(func() {
 					close(h.received)
 				})
-				return fmt.Errorf("Service is shutdown")
+				return errors.New("Service is shutdown")
 			}
 			time.Sleep(time.Millisecond * 500)
 		}
@@ -134,8 +134,8 @@ func (h *KafkaListener) HandleMessage(msg kafka.FTMessage) error {
 	select {
 	case h.received <- n:
 	case <-n.Quit:
-		log.WithField("transaction_id", tid).WithField("uuid", n.Stub.Uuid).Error("Notification handling is terminted")
-		return fmt.Errorf("Notification handling is terminted")
+		log.WithField("transaction_id", tid).WithField("uuid", n.Stub.Uuid).Error("Notification handling is terminated")
+		return errors.New("Notification handling is terminated")
 
 	}
 	if h.ShutDownPrepared {

--- a/queue/mapper.go
+++ b/queue/mapper.go
@@ -13,6 +13,7 @@ import (
 )
 
 const canBeDistributedYes = "yes"
+
 // UUIDRegexp enables to check if a string matches a UUID
 var UUIDRegexp = regexp.MustCompile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
 
@@ -77,8 +78,8 @@ func (e event) mapNotification(tid string) (*Notification, error) {
 
 	return &Notification{
 		Stub: content.Stub{
-			Uuid: UUID,
-			Date: content.GetDateOrDefault(payload),
+			Uuid:             UUID,
+			Date:             content.GetDateOrDefault(payload),
 			CanBeDistributed: canBeDistributed,
 		},
 		EvType:     evType,
@@ -114,7 +115,7 @@ func (h *KafkaMessageMapper) MapNotification(msg kafka.FTMessage) (*Notification
 
 	if n.Stub.CanBeDistributed != nil && *n.Stub.CanBeDistributed != canBeDistributedYes {
 		log.WithField("transaction_id", tid).WithField("msg", msg.Body).WithError(err).Warn("Skipping event: Content cannot be distributed.")
-	    return nil, nil
+		return nil, nil
 	}
 
 	return n, nil

--- a/queue/mapper.go
+++ b/queue/mapper.go
@@ -114,7 +114,7 @@ func (h *KafkaMessageMapper) MapNotification(msg kafka.FTMessage) (*Notification
 	}
 
 	if n.Stub.CanBeDistributed != nil && *n.Stub.CanBeDistributed != canBeDistributedYes {
-		log.WithField("transaction_id", tid).WithField("msg", msg.Body).WithError(err).Warn("Skipping event: Content cannot be distributed.")
+		log.WithField("transaction_id", tid).WithField("uuid", n.Stub.Uuid).Warn("Skipping event: Content cannot be distributed.")
 		return nil, nil
 	}
 

--- a/queue/mapper.go
+++ b/queue/mapper.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const canBeDistributedYes = "yes"
 // UUIDRegexp enables to check if a string matches a UUID
 var UUIDRegexp = regexp.MustCompile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
 
@@ -67,10 +68,18 @@ func (e event) mapNotification(tid string) (*Notification, error) {
 		}
 	}
 
+	var canBeDistributed *string
+	canBeDistributedValue, found := payload["canBeDistributed"]
+	if found {
+		canBeDistributed = new(string)
+		*canBeDistributed = canBeDistributedValue.(string)
+	}
+
 	return &Notification{
 		Stub: content.Stub{
 			Uuid: UUID,
 			Date: content.GetDateOrDefault(payload),
+			CanBeDistributed: canBeDistributed,
 		},
 		EvType:     evType,
 		Terminator: export.NewTerminator(),
@@ -101,6 +110,11 @@ func (h *KafkaMessageMapper) MapNotification(msg kafka.FTMessage) (*Notification
 	if err != nil {
 		log.WithField("transaction_id", tid).WithField("msg", msg.Body).WithError(err).Warn("Skipping event: Cannot build notification for message.")
 		return nil, err
+	}
+
+	if n.Stub.CanBeDistributed != nil && *n.Stub.CanBeDistributed != canBeDistributedYes {
+		log.WithField("transaction_id", tid).WithField("msg", msg.Body).WithError(err).Warn("Skipping event: Content cannot be distributed.")
+	    return nil, nil
 	}
 
 	return n, nil

--- a/queue/notification.go
+++ b/queue/notification.go
@@ -55,6 +55,10 @@ func (h *KafkaContentNotificationHandler) HandleContentNotification(n *Notificat
 	} else if n.EvType == DELETE {
 		logEntry.Info("DELETE event received")
 		if err := h.ContentExporter.Updater.Delete(n.Stub.Uuid, n.Tid); err != nil {
+			if err == content.ErrNotFound {
+				logEntry.Warnf("DELETE WARN: %v", err)
+				return nil
+			}
 			return fmt.Errorf("DELETE ERROR: %v", err)
 		}
 	}


### PR DESCRIPTION
This PR addresses the issue https://github.com/Financial-Times/content-exporter/issues/17

* Upon UPDATEs the `canBeDistributed` field is checked, and if it is set and is not true, then the app skips it
* Upon DELETEs the S3 writer could return a 404 for missing items - treat it as `warning` instead of error as that missing content could be not distributable