### PR TITLE
Handle case for running full export and failing healthcheck with kafka lag

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -36,6 +36,7 @@ type Job struct {
 	Status                   State             `json:"Status"`
 	ErrorMessage             string            `json:"ErrorMessage,omitempty"`
 	ContentRetrievalThrottle int               `json:"-"`
+	FullExport               bool              `json:"-"`
 }
 
 func NewFullExporter(nrOfWorkers int, exporter *content.Exporter) *Service {
@@ -78,6 +79,17 @@ func (fe *Service) AddJob(job *Job) {
 
 func (fe *Service) GetWorkerCount() int {
 	return fe.nrOfConcurrentWorkers
+}
+
+func (fe *Service) IsFullExportRunning() bool {
+	fe.RLock()
+	defer fe.RUnlock()
+	for _, job := range fe.jobs {
+		if job.FullExport && job.Status != FINISHED {
+			return true
+		}
+	}
+	return false
 }
 
 func (job *Job) Copy() Job {

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -124,7 +124,7 @@ func (service *healthService) KafkaMonitor() health.Check {
 
 func (service *healthService) customKafkaMonitorCheck() (string, error) {
 	status, err := service.config.queueHandler.MonitorCheck()
-	if !service.statusManager.IsFullExportRunning() || err == nil {
+	if err == nil || !service.statusManager.IsFullExportRunning() {
 		return status, err
 	}
 	msg := fmt.Sprintf("%s: %s", fullExportMessage, err.Error())

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -12,12 +13,16 @@ import (
 	"github.com/Financial-Times/service-status-go/gtg"
 )
 
-const healthPath = "/__health"
+const (
+	healthPath        = "/__health"
+	fullExportMessage = "Service is currently performing a full export and lag is expected"
+)
 
 type healthService struct {
-	config *healthConfig
-	checks []health.Check
-	client *http.Client
+	config        *healthConfig
+	checks        []health.Check
+	client        *http.Client
+	statusManager exportStatusManager
 }
 
 type healthConfig struct {
@@ -30,7 +35,11 @@ type healthConfig struct {
 	queueHandler           *queue.KafkaListener
 }
 
-func newHealthService(config *healthConfig) *healthService {
+type exportStatusManager interface {
+	IsFullExportRunning() bool
+}
+
+func newHealthService(config *healthConfig, statusManager exportStatusManager) *healthService {
 	tr := &http.Transport{
 		MaxIdleConnsPerHost: 10,
 		DialContext: (&net.Dialer{
@@ -42,7 +51,7 @@ func newHealthService(config *healthConfig) *healthService {
 		Transport: tr,
 		Timeout:   3 * time.Second,
 	}
-	service := &healthService{config: config, client: httpClient}
+	service := &healthService{config: config, client: httpClient, statusManager: statusManager}
 	service.checks = []health.Check{
 		service.MongoCheck(),
 		service.ReadEndpointCheck(),
@@ -106,10 +115,20 @@ func (service *healthService) KafkaMonitor() health.Check {
 	return health.Check{
 		Name:             "KafkaClientLag",
 		BusinessImpact:   "No Business Impact.",
+		PanicGuide:       "https://runbooks.in.ft.com/content-exporter",
 		Severity:         3,
 		TechnicalSummary: "Messages awaiting handling exceed the configured lag tolerance. Check if Kafka consumer is stuck.",
-		Checker:          service.config.queueHandler.MonitorCheck,
+		Checker:          service.customKafkaMonitorCheck,
 	}
+}
+
+func (service *healthService) customKafkaMonitorCheck() (string, error) {
+	status, err := service.config.queueHandler.MonitorCheck()
+	if !service.statusManager.IsFullExportRunning() || err == nil {
+		return status, err
+	}
+	msg := fmt.Sprintf("%s: %s", fullExportMessage, err.Error())
+	return msg, nil
 }
 
 func (service *healthService) GTG() gtg.Status {

--- a/helm/content-exporter/app-configs/content-exporter_eks_delivery.yaml
+++ b/helm/content-exporter/app-configs/content-exporter_eks_delivery.yaml
@@ -6,5 +6,5 @@ env:
     groupId: "content-exporter"
   s3Writer:
     baseUrl: "http://upp-exports-rw-s3:8080"
-  contentOriginAllowlist: "^http://upp-(article|content)-validator\\.svc\\.ft\\.com(:\\d{2,5})?/content/[\\w-]+.*$"
+  contentOriginAllowlist: "^http://upp-content-validator\\.svc\\.ft\\.com(:\\d{2,5})?/content/[\\w-]+.*$"
   allowedContentTypes: "Article"

--- a/helm/content-exporter/app-configs/content-exporter_eks_delivery.yaml
+++ b/helm/content-exporter/app-configs/content-exporter_eks_delivery.yaml
@@ -6,5 +6,5 @@ env:
     groupId: "content-exporter"
   s3Writer:
     baseUrl: "http://upp-exports-rw-s3:8080"
-  contentOriginAllowlist: "^http://(wordpress|upp)-(article|content)-(mapper|validator)\\.svc\\.ft\\.com(:\\d{2,5})?/content/[\\w-]+.*$"
+  contentOriginAllowlist: "^http://upp-(article|content)-validator\\.svc\\.ft\\.com(:\\d{2,5})?/content/[\\w-]+.*$"
   allowedContentTypes: "Article"

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func main() {
 				enrichedContentFetcher: fetcher,
 				s3Uploader:             uploader,
 				queueHandler:           kafkaListener,
-			})
+			}, fullExporter)
 
 		go serveEndpoints(*appSystemCode, *appName, *port, web.NewRequestHandler(fullExporter, content.NewMongoInquirer(mongo), locker, *isIncExportEnabled, *contentRetrievalThrottle), healthService)
 

--- a/web/resources.go
+++ b/web/resources.go
@@ -90,7 +90,7 @@ func (handler *RequestHandler) Export(writer http.ResponseWriter, request *http.
 	}
 
 	jobID := uuid.New()
-	job := &export.Job{ID: jobID, NrWorker: handler.FullExporter.GetWorkerCount(), Status: export.STARTING, ContentRetrievalThrottle: handler.ContentRetrievalThrottle}
+	job := &export.Job{ID: jobID, NrWorker: handler.FullExporter.GetWorkerCount(), Status: export.STARTING, ContentRetrievalThrottle: handler.ContentRetrievalThrottle, FullExport: isFullExport}
 	handler.FullExporter.AddJob(job)
 	response := map[string]string{
 		"ID":     job.ID,


### PR DESCRIPTION
@Financial-Times/content-team as the test full export is still running on Dev (it's expected to finish today after 6PM), I still haven't verified that the Job successfully changes its status to TERMINATED and then the healthcheck will be back to normal, but I'm opening the PR so you can take a look. I will confirm it tomorrow morning and proceed accordingly 

**Update**: When the full export task finished, the job changes it status as expected. The lag after the job termination was above 10k, but the service could catch-up quickly and the healthcheck was back to normal

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3351

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
